### PR TITLE
Update SLUS_202.16.md

### DIFF
--- a/List/D/SLUS_202.16.md
+++ b/List/D/SLUS_202.16.md
@@ -1,4 +1,4 @@
 # SLUS_202.16 - Devil May Cry
 
 {% include table_header %}
-| DVD5 | ZSO | OPL 1.2.0 beta 1901 | USB | 6 | YES | YES | NO | NO | Working | @INDRAPhilip | SCPH-39001 | GSM doesn't work in cutscenes, it's impossible to play with it enabled even after they finish, but in zso and iso the cutscenes work with a little lag and also in FMV with more in zso than in iso via usb 
+| DVD5 | ZSO | OPL 1.2.0 beta 1901 | USB | 6 | YES | NO | NO | NO | Working | @INDRAPhilip | SCPH-39001 | GSM doesn't work in cutscenes, it's impossible to play with it enabled even after they finish, but in zso and iso the cutscenes work with a little lag and also in FMV with more in zso than in iso via usb 

--- a/List/D/SLUS_202.16.md
+++ b/List/D/SLUS_202.16.md
@@ -2,3 +2,4 @@
 
 {% include table_header %}
 | DVD5 | ZSO | OPL 1.2.0 beta 1901 | USB | 6 | YES | NO | NO | NO | Working | @INDRAPhilip | SCPH-39001 | GSM doesn't work in cutscenes, it's impossible to play with it enabled even after they finish, but in zso and iso the cutscenes work with a little lag and also in FMV with more in zso than in iso via usb 
+| DVD5 | ISO | OPL 1.2.0 beta 1906 | USB | 6 | YES | NO | NO | NO | Working | @INDRAPhilip | SCPH-39001 | GSM doesn't work in cutscenes, it's impossible to play with it enabled even after they finish, but in zso and iso the cutscenes work with a little lag and also in FMV with more in zso than in iso via usb

--- a/List/D/SLUS_202.16.md
+++ b/List/D/SLUS_202.16.md
@@ -1,4 +1,4 @@
 # SLUS_202.16 - Devil May Cry
 
 {% include table_header %}
-| DVD5 | ZSO | OPL 1.2.0 beta 1901 | USB | 6 | YES | YES | NO | YES | Working | @INDRAPhilip | SCPH-39001 | GSM doesn't work in cutscenes, it's impossible to play with it enabled even after they finish, but in zso and iso the cutscenes work with a little lag and also in FMV with more in zso than in iso via usb 
+| DVD5 | ZSO | OPL 1.2.0 beta 1901 | USB | 6 | YES | YES | NO | NO | Working | @INDRAPhilip | SCPH-39001 | GSM doesn't work in cutscenes, it's impossible to play with it enabled even after they finish, but in zso and iso the cutscenes work with a little lag and also in FMV with more in zso than in iso via usb 


### PR DESCRIPTION
As I reported in question [72](https://github.com/ps2homebrew/Open-PS2-Loader-Compatibility-list/issues/72) that with the GSM activator there is no way to play the game it works until the home screen, but when starting the game it is impossible to play with it activated, I don't understand why the list says it works.
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [x] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Update SLUS_202.16.md as GSM doesn't work!
![IMG_20220712_231637778](https://user-images.githubusercontent.com/86567865/178636831-7cf10f5b-5e8f-45c1-947f-9cfb12a7fc5c.jpg)
![IMG_20220712_231619199](https://user-images.githubusercontent.com/86567865/178636834-0109d1c6-d248-420a-87ee-3aac17827e91.jpg)

